### PR TITLE
Julian calendar implementation

### DIFF
--- a/calendars/cjs/julian.js
+++ b/calendars/cjs/julian.js
@@ -1,0 +1,62 @@
+const julian = {
+  name: "julian",
+  startYear: 1,
+  yearLength: 365,
+  epoch: 1721422,
+  century: 20,
+  weekStartDayIndex: 1,
+  getMonthLengths(isLeap) {
+    return [31, isLeap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  },
+  isLeap(year) {
+    return (year % 4 === 0);
+  },
+  getLeaps(currentYear) {
+    if (currentYear === 0) return;
+
+    let year = currentYear > 0 ? 1 : -1;
+
+    let leaps = [],
+      condition = () =>
+        currentYear > 0 ? year <= currentYear : currentYear <= year,
+      increase = () => (currentYear > 0 ? year++ : year--);
+
+    while (condition()) {
+      if (this.isLeap(year)) leaps.push(year);
+
+      increase();
+    }
+
+    return leaps;
+  },
+  getDayOfYear({ year, month, day }) {
+    let monthLengths = this.getMonthLengths(this.isLeap(year));
+
+    for (let i = 0; i < month.index; i++) {
+      day += monthLengths[i];
+    }
+
+    return day;
+  },
+  getAllDays(date) {
+    const { year } = date;
+
+    return (
+      this.yearLength * (year - 1) +
+      this.leapsLength(year) +
+      this.getDayOfYear(date)
+    );
+  },
+  leapsLength(year) {
+    return (
+      (((year - 1) / 4) | 0)
+    );
+  },
+  guessYear(days, currentYear) {
+    let year = ~~(days / 365.25);
+
+    return year + (currentYear > 0 ? 1 : -1);
+  },
+};
+
+module.exports = julian;

--- a/index.d.ts
+++ b/index.d.ts
@@ -547,6 +547,12 @@ declare module "date-object/calendars/cjs/indian" {
   export = indian;
 }
 
+declare module "date-object/calendars/cjs/julian" {
+  const julian: Calendar;
+
+  export = julian;
+}
+
 declare module "date-object/locales/cjs/gregorian_en" {
   const gregorian_en: Locale;
 
@@ -673,6 +679,12 @@ declare module "date-object/calendars/es/indian" {
   export = indian;
 }
 
+declare module "date-object/calendars/es/julian" {
+  const julian: Calendar;
+
+  export = julian;
+}
+
 declare module "date-object/locales/es/gregorian_en" {
   const gregorian_en: Locale;
 
@@ -797,6 +809,12 @@ declare module "date-object/calendars/umd/indian" {
   const indian: Calendar;
 
   export = indian;
+}
+
+declare module "date-object/calendars/umd/julian" {
+  const julian: Calendar;
+
+  export = julian;
 }
 
 declare module "date-object/locales/umd/gregorian_en" {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-object",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "JavaScript library for working with Date and Time in different calendars and locals",
   "main": "./dist/cjs/date-object.es6.js",
   "browser": "./dist/umd/date-object.min.js",

--- a/test/date_object.test.js
+++ b/test/date_object.test.js
@@ -5,6 +5,7 @@ const persian = require("../calendars/cjs/persian");
 const jalali = require("../calendars/cjs/jalali");
 const arabic = require("../calendars/cjs/arabic");
 const indian = require("../calendars/cjs/indian");
+const julian = require("../calendars/cjs/julian");
 
 const gregorian_en = require("../locales/cjs/gregorian_en");
 const gregorian_pt_br = require("../locales/cjs/gregorian_pt_br");
@@ -64,6 +65,7 @@ describe("current moment", () => {
       .convert(persian)
       .convert(arabic)
       .convert(indian)
+      .convert(julian)
       .convert(gregorian);
 
     expect(dateObject.year).toEqual(date.getFullYear());
@@ -78,15 +80,16 @@ describe("current moment", () => {
 });
 
 describe("converting some dates", () => {
-  const calendars = [persian, arabic];
+  const calendars = [persian, arabic, julian];
 
   const dates = [
-    { gregorian: "3000/08/31", persian: "2379/06/09", arabic: "2452/02/08" },
-    { gregorian: "2847/12/20", persian: "2226/09/29", arabic: "2294/09/21" },
-    { gregorian: "2021/06/02", persian: "1400/03/12", arabic: "1442/10/21" },
-    { gregorian: "2008/11/27", persian: "1387/09/07", arabic: "1429/11/28" },
-    { gregorian: "1873/04/01", persian: "1252/01/12", arabic: "1290/02/02" },
-    { gregorian: "1211/05/14", persian: "590/02/24", arabic: "607/11/22" },
+    { gregorian: "3000/08/31", persian: "2379/06/09", arabic: "2452/02/08", julian: "3000/08/10" },
+    { gregorian: "2847/12/20", persian: "2226/09/29", arabic: "2294/09/21", julian: "2847/12/01" },
+    { gregorian: "2021/06/02", persian: "1400/03/12", arabic: "1442/10/21", julian: "2021/05/20" },
+    { gregorian: "2008/11/27", persian: "1387/09/07", arabic: "1429/11/28", julian: "2008/11/14" },
+    { gregorian: "1873/04/01", persian: "1252/01/12", arabic: "1290/02/02", julian: "1873/03/20" },
+    { gregorian: "1211/05/14", persian: "590/02/24", arabic: "607/11/22", julian: "1211/05/07" },
+    { gregorian: "650/07/22", persian: "29/04/31", arabic: "29/11/14", julian: "650/07/19" },
   ];
 
   calendars.forEach((calendar) => {
@@ -121,6 +124,10 @@ describe("converting some dates", () => {
     date.convert(indian);
 
     expect(date.format()).toEqual("1942/08/09");
+
+    date.convert(julian);
+
+    expect(date.format()).toEqual("2020/10/18");
   });
 });
 
@@ -345,10 +352,8 @@ describe("other methods", () => {
     const $gregorian = new DateObject(1604824018304);
     const $arabic = new DateObject({ date: $gregorian, calendar: arabic });
     const $indian = new DateObject({ date: $gregorian, calendar: indian });
-    const $persian = new DateObject({
-      date: $gregorian,
-      calendar: persian,
-    });
+    const $persian = new DateObject({ date: $gregorian, calendar: persian });
+    const $julian = new DateObject({ date: $gregorian, calendar: julian });
 
     expect(`${$gregorian.valueOf()} ${$gregorian.format()}`).toEqual(
       "1604824018304 2020/11/08"
@@ -364,6 +369,10 @@ describe("other methods", () => {
 
     expect(`${$arabic.valueOf()} ${$arabic.format()}`).toEqual(
       "1604824018304 1442/03/22"
+    );
+
+    expect(`${$julian.valueOf()} ${$julian.format()}`).toEqual(
+      "1604824018304 2020/10/26"
     );
 
     expect($persian - $gregorian).toEqual(0);


### PR DESCRIPTION
I created a simple implementation of a Julian calendar https://en.wikipedia.org/wiki/Julian_calendar based on the gregorian calendar implementation.

I checked it for some common dates (>45) in the test file and those seem to work. It does not deal with roman dates before 45 or the missing year 0.

It would be nice to have this as part of the official distribution.